### PR TITLE
Add progress-based NPS analyzer with GPT‑4o-mini

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# nps-survey-analyzer-
+# NPS Survey Analyzer
+
+This repository contains a simple Streamlit application for analyzing NPS survey results with help from OpenAI's **GPT-4o-mini** model. The app allows non-technical users to upload survey data, translate free-text comments to English, categorize them, generate pivot tables for structured questions, and create a narrative report.
+
+## Features
+
+- Upload CSV or Excel survey data.
+- Select which columns contain free-text responses.
+- Automatic translation of comments to English using GPT-4o-mini.
+- AI-driven categorization into a predefined list of categories.
+- Pivot tables and bar charts for structured questions.
+- Downloadable results and pivot tables.
+- Generate a narrative report and download it as a DOCX or PDF file.
+- Progress bars for long-running translation and categorization tasks.
+- Expandable comments for spot-checking AI results.
+
+## Requirements
+
+- Python 3.12
+- An OpenAI API key set as the environment variable `OPENAI_API_KEY`.
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+streamlit run app.py
+```
+
+Use the sidebar to upload your survey file. The app will guide you through selecting free-text columns, processing translations with progress bars, and generating downloadable pivot tables, charts, and reports.
+
+An example dataset `example_data.csv` is included for testing.

--- a/example_data.csv
+++ b/example_data.csv
@@ -1,0 +1,4 @@
+User_ID,Country,NPS_Score,Recommend,Comments,Additional
+1,USA,10,Yes,"Great resource! I love it","No issues"
+2,Germany,5,No,"Zu teuer, nicht gut","Konnte mich nicht anmelden"
+3,Brazil,8,Maybe,"Bom recurso, mas precisa de melhorias","Preços altos"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+streamlit
+pandas
+openai
+altair
+python-docx
+fpdf


### PR DESCRIPTION
## Summary
- support GPT-4o-mini and progress-based processing
- save reports as DOCX or PDF
- add optional country filtering and expandable comment QA
- document features and requirements

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686d9eef0dc0832c89e2f5c8a670a727