### PR TITLE
Add pivots and charts to exported reports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ openai
 altair
 python-docx
 fpdf
+
+vl-convert-python


### PR DESCRIPTION
## Summary
- allow bar_chart to save chart images
- embed pivot tables and saved charts into DOCX and PDF files
- persist generated pivot tables and chart paths in session state
- export reports with embedded tables/charts
- add `vl-convert-python` to requirements for Altair image saving

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686da6706c24832cb3a7bb8d0da98954