### PR TITLE
Enhance chart styling and downloads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ openai
 altair
 python-docx
 fpdf
+altair_saver
+vl-convert-python


### PR DESCRIPTION
## Summary
- add missing `StringIO` import
- style Altair charts with a white background and gradient colour scheme
- provide PNG/SVG downloads for each chart
- include new dependencies for saving charts

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686da677863c832c9657ba714a59bc6f