### PR TITLE
Add pivot tables and charts to report exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains a simple Streamlit application for analyzing NPS survey
 - Pivot tables with percentages and bar charts for structured questions.
 - Downloadable results and pivot tables.
 - Generate a narrative report and download it as a DOCX or PDF file.
+- Reports include pivot tables and bar chart images.
 - When multiple segments are selected, generate a report for each and download all DOCX/PDF files in a ZIP.
 - Progress bars for long-running translation and categorization tasks.
 - Expandable comments for spot-checking AI results.


### PR DESCRIPTION
## Summary
- include pivot data and charts in generated DOCX and PDF reports
- create helper utilities for chart generation
- document that reports now contain tables and bar charts

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686da9eb90b8832c9150ca9569f362d6