### PR TITLE
Add KPI computation and display before reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains a simple Streamlit application for analyzing NPS survey
 - AI-driven categorization into a predefined list of categories.
 - Pivot tables with percentages and bar charts for structured questions.
 - High-level summary dashboard showing NPS distribution, category frequency and sentiment ratio.
+- These KPIs and charts are shown before the detailed report for quick insight.
 - Downloadable results and pivot tables.
 - Generate a narrative report and download it as a DOCX or PDF file.
 - Reports include pivot tables and bar chart images.


### PR DESCRIPTION
## Summary
- compute NPS and category statistics in `compute_kpis`
- show KPIs before generating narrative report
- document KPI display in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686dade2db28832c8c5ba1fe715f86e5