### PR TITLE
Fix variable naming E741

### DIFF
--- a/app.py
+++ b/app.py
@@ -484,7 +484,7 @@ def process_free_text(df: pd.DataFrame, free_text_cols: List[str]) -> pd.DataFra
 
         trans_lang = asyncio.run(async_translate_batch(batch_texts))
         batch_trans = [t for t, _, _, _ in trans_lang]
-        batch_langs = [l for _, l, _, _ in trans_lang]
+        batch_langs = [lang for _, lang, _, _ in trans_lang]
         batch_toks_trans = [tok for _, _, tok, _ in trans_lang]
         batch_finish_trans = [fin for _, _, _, fin in trans_lang]
 


### PR DESCRIPTION
## Summary
- rename variable `l` to `lang` in `process_free_text` to avoid E741

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686dade4bc50832c8f1045634963d8cc