### PR TITLE
Handle missing OpenAI key

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,6 +18,9 @@ import zipfile
 
 # Set your OpenAI API key via environment variable
 openai.api_key = os.getenv("OPENAI_API_KEY", "")
+if not openai.api_key:
+    st.error("OpenAI API key not found. Please set the OPENAI_API_KEY environment variable.")
+    st.stop()
 MODEL = "gpt-4o-mini"
 
 # Directory for cached processed data


### PR DESCRIPTION
## Summary
- stop the app in Streamlit if `OPENAI_API_KEY` is not set

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686dade55fbc832c8c5d8261972fd484