### PR TITLE
Switch cache to parquet

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ This repository contains a simple Streamlit application for analyzing NPS survey
 - Progress bars for long-running translation and categorization tasks.
 - Expandable comments for spot-checking AI results.
 - Language detection stored alongside translations.
+- Processed data is cached in the `cache` directory as Parquet files to speed up repeated analysis.
 
 ## Requirements
 
 - Python 3.12
 - An OpenAI API key set as the environment variable `OPENAI_API_KEY`.
+- [PyArrow](https://arrow.apache.org/docs/python/) for Parquet support.
 
 Install dependencies with:
 

--- a/app.py
+++ b/app.py
@@ -531,11 +531,11 @@ file = st.sidebar.file_uploader(
 if file and validate_file(file):
     raw_bytes = file.getvalue()
     checksum = hashlib.md5(raw_bytes).hexdigest()
-    cache_path = os.path.join(CACHE_DIR, f"{checksum}.pkl")
+    cache_path = os.path.join(CACHE_DIR, f"{checksum}.parquet")
     if "processed_df" in st.session_state:
         df = st.session_state["processed_df"]
     elif os.path.exists(cache_path):
-        df = pd.read_pickle(cache_path)
+        df = pd.read_parquet(cache_path)
         st.success("Loaded cached processed data")
     else:
         try:
@@ -621,7 +621,7 @@ if file and validate_file(file):
 
         df = review_translations(df, user_id_col)
         st.session_state["processed_df"] = df
-        df.to_pickle(cache_path)
+        df.to_parquet(cache_path, index=False)
 
         nps_col = next((c for c in structured_cols if "nps" in c.lower()), None)
         display_summary(df, nps_col)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-docx
 fpdf
 altair_saver
 vl-convert-python
+pyarrow


### PR DESCRIPTION
## Summary
- cache processed data in `.parquet` files instead of pickles
- document PyArrow requirement and caching behaviour

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686dadec69a0832c93c0fa4d0e1ac767