### PR TITLE
Switch cache hashing to SHA-256

### DIFF
--- a/app.py
+++ b/app.py
@@ -530,7 +530,8 @@ file = st.sidebar.file_uploader(
 
 if file and validate_file(file):
     raw_bytes = file.getvalue()
-    checksum = hashlib.md5(raw_bytes).hexdigest()
+    # Use SHA-256 rather than MD5 to generate a cache key for the uploaded file
+    checksum = hashlib.sha256(raw_bytes).hexdigest()
     cache_path = os.path.join(CACHE_DIR, f"{checksum}.pkl")
     if "processed_df" in st.session_state:
         df = st.session_state["processed_df"]


### PR DESCRIPTION
## Summary
- replace md5 with sha256 when caching uploaded files
- add clarifying comment on hashing strategy

## Testing
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_686daded46f4832cb69d7cdfbc6ab273