### PR TITLE
Add full results Excel export

### DIFF
--- a/app.py
+++ b/app.py
@@ -347,6 +347,20 @@ def export_excel(df: pd.DataFrame, filename: str, label: str, help: str | None =
     )
 
 
+def export_full_excel(df: pd.DataFrame, filename: str, label: str, help: str | None = None):
+    """Download the entire processed DataFrame as an Excel file."""
+    buffer = BytesIO()
+    with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:
+        df.to_excel(writer, index=False)
+    st.download_button(
+        label,
+        buffer.getvalue(),
+        file_name=filename,
+        mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        help=help,
+    )
+
+
 def read_uploaded_file(uploaded_file) -> pd.DataFrame | None:
     """Load an uploaded CSV or Excel file with encoding validation."""
     raw_bytes = uploaded_file.getvalue()
@@ -770,6 +784,12 @@ if file and validate_file(file):
             "full_results.csv",
             "Download All Results",
             help="Save the full dataset with translations and categories."
+        )
+        export_full_excel(
+            df,
+            "full_results.xlsx",
+            "Download All Results Excel",
+            help="Save the full dataset as an Excel file."
         )
 
         if st.button(


### PR DESCRIPTION
## Summary
- add `export_full_excel` for exporting the processed DataFrame to XLSX
- allow downloading full results as XLSX alongside the CSV option

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686e3046597c832c8615b46b72b69801