### PR TITLE
Enable multi-segment filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository contains a simple Streamlit application for analyzing NPS survey
 - These KPIs and charts are shown before the detailed report for quick insight.
 - Downloadable results and pivot tables.
 - Generate a narrative report and download it as a DOCX or PDF file.
+- Filter data by multiple segment columns at once (e.g., Country and Career Type).
 - Reports include pivot tables and bar chart images.
 - When multiple segments are selected, generate a report for each and download all DOCX/PDF files in a ZIP.
 - Progress bars for long-running translation and categorization tasks.


### PR DESCRIPTION
## Summary
- allow choosing additional segment columns and value filters
- filter data by those extra columns before analysis and when generating reports
- document multi-segment filtering in features list

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686e4d2338f8832c99133f5940b6bb90