### PR TITLE
Improve translation skipping and results export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-docx
 fpdf
 altair_saver
 vl-convert-python
+langdetect


### PR DESCRIPTION
## Summary
- add `langdetect` dependency and new helper to detect language locally
- skip OpenAI translation call when text is already English
- store clearer finish reason and show `Unknown` when User ID missing
- export filtered data to Excel instead of full DataFrame

## Testing
- `pytest -q`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686e682d35e0832ca8ae2a3dfe821dbd