### PR TITLE
Add vertical scrolling to app

### DIFF
--- a/app.py
+++ b/app.py
@@ -734,6 +734,8 @@ def apply_style():
             html, body, [class*="css"]  { font-family: 'Roboto', sans-serif; }
             [data-testid="stAppViewContainer"] {
                 background: linear-gradient(135deg, #f4f8fb 0%, #e0ecff 100%);
+                height: 100vh;
+                overflow-y: auto;
             }
             .stButton>button {
                 background-color: #0E79B2;


### PR DESCRIPTION
## Summary
- update the injected CSS in `apply_style` to set the main container height to `100vh` and allow vertical scrolling

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686e9894aad0832c85cb2adf17e07cd6