### PR TITLE
Add row count summary after applying filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The question **"1: How likely are you to recommend Twinkl to a friend or colleag
 - AI-driven categorization into a predefined list of categories.
 - Pivot tables with percentages and bar charts for structured questions.
 - High-level summary dashboard showing NPS score, distribution, category frequency and sentiment ratio.
+- Displays the number of rows after filters are applied.
 - These KPIs and charts are shown before the detailed report for quick insight.
 - Downloadable results and pivot tables.
 - Generate a narrative report and download it as a DOCX or PDF file.

--- a/app.py
+++ b/app.py
@@ -640,6 +640,7 @@ def compute_kpis(
 def display_summary(df: pd.DataFrame, nps_col: str | None):
     """Show high-level KPIs and charts."""
     st.subheader("🚀 High-Level KPIs")
+    st.metric("Rows After Filters", len(df))
     nps_pivot, cat_pivot, (pos, neg), nps_score = compute_kpis(df, nps_col)
     if nps_score is not None:
         st.metric("NPS Score", nps_score)
@@ -1459,8 +1460,9 @@ if file and validate_file(file):
                         if seg_df.empty:
                             continue
                         segment_title = segment if segment is not None else "All"
-    
+
                         st.markdown(f"## KPIs for {segment_title}")
+                        st.metric("Rows in Segment", len(seg_df))
                         nps_pivot, cat_pivot, (pos, neg), nps_score = compute_kpis(seg_df, nps_col)
                         if nps_score is not None:
                             st.metric("NPS Score", nps_score)


### PR DESCRIPTION
## Summary
- show row count in high-level KPIs after filters are applied
- report row count for each segment when generating segment KPIs
- document the new summary metric in README

## Testing
- `python -m py_compile app.py`
- `flake8 app.py`

------
https://chatgpt.com/codex/tasks/task_e_686ec8550f88832cab18c55e75743a29