### PR TITLE
Add clear cached data button

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The question **"1: How likely are you to recommend Twinkl to a friend or colleag
 - Language detection stored alongside translations.
 - Intermediate results saved after each processing batch.
 - Automatically resume processing from the last completed row on startup.
+- Clear cached data for the uploaded survey using the **Clear Cached Data** button.
 
 ## Requirements
 
@@ -59,5 +60,6 @@ If the app fails to start or behaves unexpectedly, try the following:
    issues.
 3. **Large files** – the uploader accepts files up to 10MB.
 4. **Encoding issues** – save your CSV in UTF-8 format.
+5. **Stale results** – click **Clear Cached Data** in the sidebar to remove saved progress.
 
 For more help open an issue on GitHub.

--- a/app.py
+++ b/app.py
@@ -1078,6 +1078,15 @@ if file and validate_file(file):
     checksum = hashlib.sha256(raw_bytes).hexdigest()
     cache_path = os.path.join(CACHE_DIR, f"{checksum}.pkl")
     partial_path = os.path.join(CACHE_DIR, f"{checksum}_partial.pkl")
+
+    if st.sidebar.button("Clear Cached Data"):
+        if os.path.exists(cache_path):
+            os.remove(cache_path)
+        if os.path.exists(partial_path):
+            os.remove(partial_path)
+        st.session_state.pop("processed_df", None)
+        st.sidebar.success("Cached data cleared")
+
     if "processed_df" in st.session_state:
         df = st.session_state["processed_df"]
     elif os.path.exists(cache_path):


### PR DESCRIPTION
## Summary
- add sidebar button to remove cached survey progress
- document new cache clearing option in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686ed091c5a4832c9716ec0cae917a81