### PR TITLE
Add black text & blue buttons toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The question **"1: How likely are you to recommend Twinkl to a friend or colleag
 - Intermediate results saved after each processing batch.
 - Automatically resume processing from the last completed row on startup.
 - Clear cached data for the uploaded survey using the **Clear Cached Data** button.
+- Toggle to switch all text to black and buttons to blue.
 
 ## Requirements
 

--- a/app.py
+++ b/app.py
@@ -1061,6 +1061,37 @@ def apply_style():
 
 
 apply_style()
+
+# Sidebar toggle to switch to black text and blue buttons
+if "contrast_mode" not in st.session_state:
+    st.session_state["contrast_mode"] = False
+
+contrast_toggle = st.sidebar.toggle(
+    "Black text and blue buttons",
+    value=st.session_state["contrast_mode"],
+)
+st.session_state["contrast_mode"] = contrast_toggle
+
+if contrast_toggle:
+    st.markdown(
+        """
+        <style id="contrast-style">
+            html, body, [class*="css"] { color: #000 !important; }
+            .stButton>button {
+                background-color: #0E79B2 !important;
+                color: #fff !important;
+            }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+else:
+    st.markdown(
+        """
+        <style id="contrast-style"></style>
+        """,
+        unsafe_allow_html=True,
+    )
 st.title("NPS Survey Analyzer")
 
 st.sidebar.header("1. Upload Survey Data")


### PR DESCRIPTION
## Summary
- add contrast mode toggle to let users switch text and button styles
- document the new toggle in features list

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686ed8212b9c832cba7ea29bee40675a