### PR TITLE
Force black text theme

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,4 @@
+[theme]
+base="light"
+primaryColor="#0E79B2"
+textColor="#000000"

--- a/app.py
+++ b/app.py
@@ -1030,7 +1030,10 @@ def apply_style():
         """
         <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
         <style>
-            html, body, [class*="css"]  { font-family: 'Roboto', sans-serif; }
+            html, body, [class*="css"]  {
+                font-family: 'Roboto', sans-serif;
+                color: #000;
+            }
             [data-testid="stAppViewContainer"] {
                 background: linear-gradient(135deg, #f4f8fb 0%, #e0ecff 100%);
                 height: 100vh;
@@ -1064,7 +1067,7 @@ apply_style()
 
 # Sidebar toggle to switch to black text and blue buttons
 if "contrast_mode" not in st.session_state:
-    st.session_state["contrast_mode"] = False
+    st.session_state["contrast_mode"] = True
 
 contrast_toggle = st.sidebar.toggle(
     "Black text and blue buttons",


### PR DESCRIPTION
## Summary
- keep the default page style black by setting text color in the CSS
- default the "Black text and blue buttons" toggle to enabled
- add a Streamlit config to always load the light theme

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686edd836b50832cba57e0034b7b94d0