### PR TITLE
Add PDF export for all charts and tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The question **"1: How likely are you to recommend Twinkl to a friend or colleag
 - Displays the number of rows after filters are applied.
 - These KPIs and charts are shown before the detailed report for quick insight.
 - Downloadable results and pivot tables.
+- Download all charts and tables as a single PDF.
 - Generate a narrative report and download it as a DOCX or PDF file.
 - Filter data by multiple segment columns at once (e.g., Country and Career Type).
 - Quickly apply predefined segment filters such as **UK Parents** or **US Teachers**.


### PR DESCRIPTION
## Summary
- allow export of all charts/tables into a single PDF
- document chart PDF download capability

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686ee9eb4110832cb28fa56a15eeea6b