### PR TITLE
Default 'Show detailed comments' unchecked

### DIFF
--- a/app.py
+++ b/app.py
@@ -1317,7 +1317,7 @@ if file and validate_file(file):
 
     show_comments = st.checkbox(
         "Show detailed comments",
-        value=True,
+        value=False,
         help="Display each comment with its categories for manual review.",
     )
 


### PR DESCRIPTION
## Summary
- make 'Show detailed comments' unchecked when loading the app

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686eede42214832ca27eba767a22aec2