### PR TITLE
Add tables PDF download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The question **"1: How likely are you to recommend Twinkl to a friend or colleag
 - These KPIs and charts are shown before the detailed report for quick insight.
 - Downloadable results and pivot tables.
 - Use the **Download Charts PDF** button to save all graphs with their question explanations.
+- Use the **Download Tables PDF** button to save each pivot table with its question text.
 - Use the **Download Everything PDF** button to save all charts, tables and the report in one file.
 - Generate a narrative report and download it as a DOCX or via **Download Everything PDF**.
 - Filter data by multiple segment columns at once (e.g., Country and Career Type).


### PR DESCRIPTION
## Summary
- allow generating PDF with tables only via `save_pdf(include_charts=False)`
- add **Download Tables PDF** buttons in sidebar, main analysis and segment reports
- update README with new feature

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fa6912aac832c9d7b4c720d19c13b