### PR TITLE
Add charts PDF export button

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ The question **"1: How likely are you to recommend Twinkl to a friend or colleag
 - Displays the number of rows after filters are applied.
 - These KPIs and charts are shown before the detailed report for quick insight.
 - Downloadable results and pivot tables.
-- Use the **Download Charts PDF** button to save all graphs with their question explanations.
+- Use the **Download Charts PDF** button to save all graphs with their question titles.
 - Use the **Download Tables PDF** button to save each pivot table with its question text.
+- A second **Download Charts PDF** button appears after processing so you can download the graphs at the end as well.
 - Use the **Download Everything PDF** button to save all charts, tables and the report in one file.
 - Generate a narrative report and download it as a DOCX or via **Download Everything PDF**.
 - Filter data by multiple segment columns at once (e.g., Country and Career Type).

--- a/app.py
+++ b/app.py
@@ -971,9 +971,24 @@ def save_docx(text: str, pivots: dict[str, pd.DataFrame]) -> BytesIO:
 
 
 def save_pdf(
-    text: str, pivots: dict[str, pd.DataFrame], include_charts: bool = True
+    text: str,
+    pivots: dict[str, pd.DataFrame],
+    include_charts: bool = True,
+    include_tables: bool = True,
 ) -> BytesIO:
-    """Save text and pivot tables as a PDF, optionally including charts."""
+    """Save text, charts and tables as a PDF.
+
+    Parameters
+    ----------
+    text : str
+        Introductory text to display at the top of the PDF.
+    pivots : dict[str, pd.DataFrame]
+        Mapping of question titles to pivot DataFrames.
+    include_charts : bool, optional
+        Include chart images under each question, by default ``True``.
+    include_tables : bool, optional
+        Include pivot tables under each question, by default ``True``.
+    """
     pdf = FPDF()
     pdf.add_page()
     pdf.set_auto_page_break(True, margin=15)
@@ -985,18 +1000,19 @@ def save_pdf(
         pdf.ln(5)
         pdf.set_font("Arial", "B", 12)
         pdf.cell(0, 10, title, ln=True)
-        pdf.set_font("Arial", size=10)
-        col_widths = [80, 30, 30]
-        headers = list(pivot.columns)
-        for i, h in enumerate(headers):
-            w = col_widths[i] if i < len(col_widths) else 30
-            pdf.cell(w, 8, str(h), border=1)
-        pdf.ln()
-        for _, row in pivot.iterrows():
+        if include_tables:
+            pdf.set_font("Arial", size=10)
+            col_widths = [80, 30, 30]
+            headers = list(pivot.columns)
             for i, h in enumerate(headers):
                 w = col_widths[i] if i < len(col_widths) else 30
-                pdf.cell(w, 8, str(row[h]), border=1)
+                pdf.cell(w, 8, str(h), border=1)
             pdf.ln()
+            for _, row in pivot.iterrows():
+                for i, h in enumerate(headers):
+                    w = col_widths[i] if i < len(col_widths) else 30
+                    pdf.cell(w, 8, str(row[h]), border=1)
+                pdf.ln()
         if include_charts:
             img = chart_png(pivot, f"{title} Responses")
             with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
@@ -1339,7 +1355,8 @@ if file and validate_file(file):
 
     if st.session_state.get("pdf_pivots"):
         pdf_buf_charts = save_pdf(
-            "NPS Survey Charts and Tables", st.session_state["pdf_pivots"]
+            "NPS Survey Charts", st.session_state["pdf_pivots"],
+            include_charts=True, include_tables=False
         )
         st.download_button(
             "Download Charts PDF",
@@ -1677,14 +1694,27 @@ if file and validate_file(file):
                     key=unique_key("all_pivots_zip"),
                 )
             if pdf_pivots:
-                pdf_buf = save_pdf("NPS Survey Charts and Tables", pdf_pivots)
+                pdf_buf_all = save_pdf("NPS Survey Charts and Tables", pdf_pivots)
                 st.session_state["pdf_pivots"] = pdf_pivots
                 st.download_button(
                     "Download Everything PDF",
-                    pdf_buf,
+                    pdf_buf_all,
                     "all_charts_tables.pdf",
                     help="Download all analysis results as a single PDF.",
                     key=unique_key("all_pivots_pdf"),
+                )
+                pdf_buf_charts = save_pdf(
+                    "NPS Survey Charts",
+                    pdf_pivots,
+                    include_charts=True,
+                    include_tables=False,
+                )
+                st.download_button(
+                    "Download Charts PDF",
+                    pdf_buf_charts,
+                    "all_charts.pdf",
+                    help="Download every chart with its question text.",
+                    key=unique_key("all_charts_pdf"),
                 )
                 pdf_tables = save_pdf(
                     "NPS Survey Tables", pdf_pivots, include_charts=False
@@ -1758,6 +1788,9 @@ if file and validate_file(file):
                             pivot_dict["NPS Distribution"] = nps_pivot
                         docx_file = save_docx(report_text, pivot_dict)
                         pdf_file = save_pdf(report_text, pivot_dict)
+                        pdf_charts = save_pdf(
+                            report_text, pivot_dict, include_charts=True, include_tables=False
+                        )
                         pdf_tables = save_pdf(
                             report_text, pivot_dict, include_charts=False
                         )
@@ -1777,6 +1810,13 @@ if file and validate_file(file):
                                 key=unique_key(f"{segment_title}_pdf"),
                             )
                             st.download_button(
+                                "Download Charts PDF",
+                                pdf_charts,
+                                f"{segment_title}_charts.pdf",
+                                help="PDF containing each chart with question text only.",
+                                key=unique_key(f"{segment_title}_charts_pdf"),
+                            )
+                            st.download_button(
                                 "Download Tables PDF",
                                 pdf_tables,
                                 f"{segment_title}_tables.pdf",
@@ -1786,6 +1826,7 @@ if file and validate_file(file):
                         else:
                             zipf.writestr(f"{segment_title}_report.docx", docx_file.getvalue())
                             zipf.writestr(f"{segment_title}_report.pdf", pdf_file.getvalue())
+                            zipf.writestr(f"{segment_title}_charts.pdf", pdf_charts.getvalue())
                             zipf.writestr(
                                 f"{segment_title}_tables.pdf", pdf_tables.getvalue()
                             )


### PR DESCRIPTION
## Summary
- allow saving charts or tables separately in a PDF by expanding `save_pdf`
- add **Download Charts PDF** button after analysis results
- offer charts PDF for each segment report
- update README with new download option

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686fb14367b4832c9270b9739cd60fe9