### PR TITLE
Enhance free-text concatenation validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ from fpdf import FPDF
 import tempfile
 import zipfile
 import uuid
+from utils import concat_series
 
 # Set your OpenAI API key via environment variable
 # Use an environment variable if available but also allow entering the API key
@@ -1037,10 +1038,7 @@ def process_free_text(df: pd.DataFrame, free_text_cols: List[str], cache_path: s
     restarted.
     """
 
-    concat_series = (
-        df[free_text_cols].fillna("").apply(lambda r: " ".join(str(x) for x in r), axis=1)
-    )
-    df["Concatenated"] = concat_series
+    df["Concatenated"] = concat_series(df, free_text_cols)
 
     # Ensure output columns exist
     for col, default in [

--- a/tests/test_concat_series.py
+++ b/tests/test_concat_series.py
@@ -1,0 +1,42 @@
+import pandas as pd
+import pytest
+from unittest.mock import MagicMock
+
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import utils
+
+
+def test_concat_series_with_missing_column(monkeypatch):
+    df = pd.DataFrame({"a": ["x"]})
+    st = MagicMock()
+    monkeypatch.setattr(utils, "st", st)
+    with pytest.raises(KeyError):
+        utils.concat_series(df, ["a", "b"])
+    st.error.assert_called_once()
+
+
+def test_concat_series_with_nan_and_blank(monkeypatch):
+    df = pd.DataFrame({
+        "a": ["foo", None, ""],
+        "b": ["bar", "baz", None],
+    })
+    st = MagicMock()
+    monkeypatch.setattr(utils, "st", st)
+    result = utils.concat_series(df, ["a", "b"])
+    assert result.tolist() == ["foo bar", " baz", " "]
+    st.error.assert_not_called()
+    st.warning.assert_not_called()
+
+
+def test_concat_series_warns_on_blank_column(monkeypatch):
+    df = pd.DataFrame({
+        "a": ["", ""],
+        "b": ["hello", "world"],
+    })
+    st = MagicMock()
+    monkeypatch.setattr(utils, "st", st)
+    result = utils.concat_series(df, ["a", "b"])
+    assert result.tolist() == [" hello", " world"]
+    st.warning.assert_called_once()

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import streamlit as st
+from typing import List
+
+
+def concat_series(df: pd.DataFrame, free_text_cols: List[str]) -> pd.Series:
+    """Concatenate multiple free-text columns into a single Series.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        DataFrame containing the survey data.
+    free_text_cols : List[str]
+        Columns to concatenate.
+
+    Returns
+    -------
+    pd.Series
+        Concatenated free-text for each row.
+
+    Raises
+    ------
+    KeyError
+        If any of the requested columns are not present in ``df``.
+    """
+    missing = [c for c in free_text_cols if c not in df.columns]
+    if missing:
+        msg = f"Missing columns: {', '.join(missing)}"
+        st.error(msg)
+        raise KeyError(msg)
+
+    # Build concatenated series
+    series = df[free_text_cols].fillna("").apply(lambda r: " ".join(str(x) for x in r), axis=1)
+
+    # Warn about completely blank columns
+    empty_cols = [c for c in free_text_cols if df[c].fillna("").astype(str).str.strip().eq("").all()]
+    if empty_cols:
+        st.warning(
+            "The following columns contain only empty strings: "
+            + ", ".join(empty_cols)
+            + ". Please review your selections."
+        )
+
+    return series


### PR DESCRIPTION
## Summary
- extract `concat_series` helper
- validate requested free-text columns exist
- warn when selected free-text columns are blank
- update `process_free_text` to use new helper
- add unit tests covering error and warning cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fdd02eff8832cb9e3187906442d29