### PR TITLE
Add original text categorization and editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ The question **"1: How likely are you to recommend Twinkl to a friend or colleag
 - Uses OpenAI's async client for faster batch processing.
 - Expandable comments for spot-checking AI results.
 - Language detection stored alongside translations.
+- Categories are generated for the original text and for the English
+  translation with editable reasoning.
 - Intermediate results saved after each processing batch.
 - Automatically resume processing from the last completed row on startup.
 - Clear cached data for the uploaded survey using the **Clear Cached Data** button.

--- a/app.py
+++ b/app.py
@@ -147,6 +147,8 @@ EXCLUDED_STRUCTURED_COLUMNS = [
     "Concatenated",
     "Translated",
     "CategoryReasoning",
+    "OriginalCategories",
+    "OriginalCategoryReasoning",
     "FinishReason",
     "Flagged",
     "ModelTokens",
@@ -881,16 +883,32 @@ def review_translations(df: pd.DataFrame, id_col: str) -> pd.DataFrame:
             st.write("**Original:**", row["Concatenated"])
             st.write(f"Tokens used: {row.get('ModelTokens', 0)}")
             st.write(f"Finish reason: {row.get('FinishReason', '')}")
+            if show_reasoning and row.get("OriginalCategoryReasoning"):
+                st.write(
+                    "**Original Reasoning:**",
+                    row["OriginalCategoryReasoning"],
+                )
             if show_reasoning and row.get("CategoryReasoning"):
-                st.write("**Reasoning:**", row["CategoryReasoning"])
+                st.write("**Translated Reasoning:**", row["CategoryReasoning"])
             new_trans = st.text_area(
                 "Translated",
                 value=row["Translated"],
                 key=f"trans_{idx}",
                 help="Edit the AI translation if it looks incorrect.",
             )
+            new_orig_cats = st.multiselect(
+                "Original Categories",
+                options=CATEGORIES,
+                default=[
+                    c.strip()
+                    for c in row.get("OriginalCategories", "").split(",")
+                    if c
+                ],
+                key=f"orig_cat_{idx}",
+                help="Edit categories for the original text.",
+            )
             new_cats = st.multiselect(
-                "Categories",
+                "Translated Categories",
                 options=CATEGORIES,
                 default=[c.strip() for c in row["Categories"].split(",") if c],
                 key=f"cat_{idx}",
@@ -900,6 +918,7 @@ def review_translations(df: pd.DataFrame, id_col: str) -> pd.DataFrame:
                 "Flag for review", key=f"flag_{idx}", help="Mark this comment for manual follow-up."
             )
             df.at[idx, "Translated"] = new_trans
+            df.at[idx, "OriginalCategories"] = ", ".join(new_orig_cats)
             df.at[idx, "Categories"] = ", ".join(new_cats)
             flags.append(flag)
     df["Flagged"] = flags
@@ -1048,6 +1067,8 @@ def process_free_text(df: pd.DataFrame, free_text_cols: List[str], cache_path: s
         ("Language", ""),
         ("Categories", ""),
         ("CategoryReasoning", ""),
+        ("OriginalCategories", ""),
+        ("OriginalCategoryReasoning", ""),
         ("ModelTokens", 0),
         ("FinishReason", ""),
     ]:
@@ -1071,6 +1092,12 @@ def process_free_text(df: pd.DataFrame, free_text_cols: List[str], cache_path: s
         batch_indices = to_process[batch_start : batch_start + batch_size]
         batch_texts = [df.at[idx, "Concatenated"] for idx in batch_indices]
 
+        orig_cats_data = asyncio.run(async_categorize_batch(batch_texts))
+        batch_orig_cats = [cats for cats, _, _, _ in orig_cats_data]
+        batch_orig_reason = [reason for _, reason, _, _ in orig_cats_data]
+        batch_toks_orig = [tok for _, _, tok, _ in orig_cats_data]
+        batch_finish_orig = [fin for _, _, _, fin in orig_cats_data]
+
         trans_lang = asyncio.run(async_translate_batch(batch_texts))
         batch_trans = [t for t, _, _, _ in trans_lang]
         batch_langs = [lang for _, lang, _, _ in trans_lang]
@@ -1088,13 +1115,23 @@ def process_free_text(df: pd.DataFrame, free_text_cols: List[str], cache_path: s
             df.at[idx, "Language"] = batch_langs[offset]
             df.at[idx, "Categories"] = ", ".join(batch_cats[offset])
             df.at[idx, "CategoryReasoning"] = batch_reason[offset]
-            df.at[idx, "ModelTokens"] = batch_toks_trans[offset] + batch_toks_cat[offset]
+            df.at[idx, "OriginalCategories"] = ", ".join(batch_orig_cats[offset])
+            df.at[idx, "OriginalCategoryReasoning"] = batch_orig_reason[offset]
+            total_tokens = (
+                batch_toks_trans[offset]
+                + batch_toks_cat[offset]
+                + batch_toks_orig[offset]
+            )
+            df.at[idx, "ModelTokens"] = total_tokens
+            fin_orig = batch_finish_orig[offset]
             fin_trans = batch_finish_trans[offset]
             fin_cat = batch_finish_cat[offset]
-            if fin_trans == fin_cat:
+            if fin_orig == fin_trans == fin_cat:
                 df.at[idx, "FinishReason"] = fin_trans
             else:
-                df.at[idx, "FinishReason"] = f"T:{fin_trans}; C:{fin_cat}"
+                df.at[idx, "FinishReason"] = (
+                    f"O:{fin_orig}; T:{fin_trans}; C:{fin_cat}"
+                )
 
         processed = batch_start + len(batch_indices)
         rate = (time.time() - start_time) / (processed if processed else 1)
@@ -1413,6 +1450,8 @@ if file and validate_file(file):
                 "Language",
                 "Categories",
                 "CategoryReasoning",
+                "OriginalCategories",
+                "OriginalCategoryReasoning",
                 "ModelTokens",
                 "FinishReason",
             ]:
@@ -1751,6 +1790,7 @@ if file and validate_file(file):
                 "Concatenated",
                 "Translated",
                 "Language",
+                "OriginalCategories",
                 "Categories",
                 "ModelTokens",
                 "FinishReason",


### PR DESCRIPTION
## Summary
- categorize text before translation and store results in `OriginalCategories` and `OriginalCategoryReasoning`
- include tokens and finish reasons from all API calls
- expose original category data for editing in the UI
- display both category sets in the final comments table
- document new behaviour in README

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686fdd1a2f08832c9bc1a4b78552a8eb