### PR TITLE
Fix overlapping labels in stacked bar charts

### DIFF
--- a/app.py
+++ b/app.py
@@ -555,7 +555,7 @@ def stacked_bar_chart(pivot: pd.DataFrame, title: str, order: List[str] | None =
             x=alt.X(
                 "Aspect_wrapped:N",
                 title="Aspect",
-                axis=alt.Axis(labelAngle=0, labelLimit=0),
+                axis=alt.Axis(labelAngle=-90, labelLimit=0),
             ),
             y=alt.Y(
                 "Count:Q",


### PR DESCRIPTION
## Summary
- rotate x-axis labels vertically for stacked bar charts

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686fddd86410832c97f45ce648c23c09