### PR TITLE
Fix reprocessing when free-text selection changes

### DIFF
--- a/app.py
+++ b/app.py
@@ -1099,7 +1099,23 @@ def process_free_text(
         Number of rows to process concurrently in each batch.
     """
 
-    df["Concatenated"] = concat_series(df, free_text_cols)
+    new_concat = concat_series(df, free_text_cols)
+    if "Concatenated" in df.columns:
+        changed_mask = new_concat != df["Concatenated"]
+        if changed_mask.any():
+            for col, default in [
+                ("Translated", ""),
+                ("Language", ""),
+                ("Categories", ""),
+                ("CategoryReasoning", ""),
+                ("OriginalCategories", ""),
+                ("OriginalCategoryReasoning", ""),
+                ("ModelTokens", 0),
+                ("FinishReason", ""),
+            ]:
+                if col in df.columns:
+                    df.loc[changed_mask, col] = default
+    df["Concatenated"] = new_concat
 
     # Ensure output columns exist
     for col, default in [

--- a/tests/test_process_free_text.py
+++ b/tests/test_process_free_text.py
@@ -1,0 +1,41 @@
+import pandas as pd
+from unittest.mock import MagicMock
+import tempfile
+import os
+import app
+
+
+async def fake_translate_batch(texts):
+    return [(text + "_t", "en", 1, "") for text in texts]
+
+
+async def fake_categorize_batch(texts):
+    return [(["C"], "r", 1, "") for _ in texts]
+
+
+def test_process_free_text_reprocesses_on_concat_change(monkeypatch, tmp_path):
+    df = pd.DataFrame({"a": ["foo"], "b": ["bar"]})
+    df["Concatenated"] = df["a"]
+    df["Translated"] = ["OLD"]
+    df["Language"] = ""
+    df["Categories"] = ""
+    df["CategoryReasoning"] = ""
+    df["OriginalCategories"] = ""
+    df["OriginalCategoryReasoning"] = ""
+    df["ModelTokens"] = 0
+    df["FinishReason"] = ""
+
+    monkeypatch.setattr(app, "async_translate_batch", fake_translate_batch)
+    monkeypatch.setattr(app, "async_categorize_batch", fake_categorize_batch)
+
+    st = MagicMock()
+    progress = MagicMock()
+    st.progress.return_value = progress
+    monkeypatch.setattr(app, "st", st)
+
+    cache_path = os.path.join(tmp_path, "cache.pkl")
+
+    result = app.process_free_text(df, ["a", "b"], cache_path, batch_size=1)
+
+    assert result["Concatenated"].iloc[0] == "foo bar"
+    assert result["Translated"].iloc[0] == "foo bar_t"


### PR DESCRIPTION
## Summary
- reset AI-generated fields when the concatenated text changes
- add tests for `process_free_text` ensuring rows are reprocessed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fe7888804832c9264e23bed1d98b1