### PR TITLE
Handle customer service feedback as free text

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,6 +131,7 @@ DEFAULT_FREE_TEXT_COLUMNS = [
     "4: Please tell us more on how we can improve your experience with Twinkl.",
     "7: We'd love to know more about your answers, especially where we can improve your website experience.",
     "10: We'd love to know more about your answers, especially where we can improve the quality of our content for you.",
+    "17: We'd love to know more about your answers, especially where we can improve our customer service to you.",
     "22: How can we improve your understanding of your membership and any of the products and features you already use?",
     "23: We’d love to understand more about your answer to this question, and how we can make your subscription easier to understand.",
     "24: Is there anything else you would like to tell us about your Twinkl experience?",
@@ -160,6 +161,7 @@ EXCLUDED_STRUCTURED_COLUMNS = [
     "Flagged",
     "ModelTokens",
     "10: We'd love to know more about your answers, especially where we can improve the quality of our content for you.",
+    "17: We'd love to know more about your answers, especially where we can improve our customer service to you.",
 ]
 
 # Predefined segment configurations used to auto-populate filters


### PR DESCRIPTION
## Summary
- treat the customer service feedback column as free text
- exclude it from structured analysis

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686febc5d4d8832c94d1522f8c87d39c