### PR TITLE
Add partial cache creation test

### DIFF
--- a/tests/test_process_free_text.py
+++ b/tests/test_process_free_text.py
@@ -39,3 +39,23 @@ def test_process_free_text_reprocesses_on_concat_change(monkeypatch, tmp_path):
 
     assert result["Concatenated"].iloc[0] == "foo bar"
     assert result["Translated"].iloc[0] == "foo bar_t"
+
+
+def test_process_free_text_creates_partial_file(monkeypatch, tmp_path):
+    df = pd.DataFrame({"a": ["x"], "b": ["y"]})
+
+    monkeypatch.setattr(app, "async_translate_batch", fake_translate_batch)
+    monkeypatch.setattr(app, "async_categorize_batch", fake_categorize_batch)
+
+    st = MagicMock()
+    progress = MagicMock()
+    st.progress.return_value = progress
+    monkeypatch.setattr(app, "st", st)
+
+    cache_path = os.path.join(tmp_path, "cache.pkl")
+    partial_path = os.path.join(tmp_path, "cache_partial.pkl")
+
+    result = app.process_free_text(df, ["a", "b"], cache_path, batch_size=1)
+
+    assert os.path.exists(partial_path)
+    os.remove(partial_path)


### PR DESCRIPTION
## Summary
- ensure process_free_text writes out a `_partial.pkl` cache

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fef35e9d0832c8b2d530595b45dd1