### PR TITLE
Remove Positive/Negative Ratio metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The question **"1: How likely are you to recommend Twinkl to a friend or colleag
 - AI-driven categorization into a predefined list of categories.
 - Pivot tables with percentages and bar charts for structured questions.
 - Binary multi-select columns with values 0 or 1 are grouped into a single pivot table.
-- High-level summary dashboard showing NPS score, distribution, category frequency and sentiment ratio.
+- High-level summary dashboard showing NPS score, distribution and category frequency.
 - Displays the number of rows after filters are applied.
 - These KPIs and charts are shown before the detailed report for quick insight.
 - Downloadable results and pivot tables.

--- a/app.py
+++ b/app.py
@@ -853,7 +853,6 @@ def display_summary(df: pd.DataFrame, nps_col: str | None):
         cat_chart = cat_pivot[cat_pivot["Category"] != "Uncategorized"]
         if not cat_chart.empty:
             bar_chart(cat_chart, "Category Frequency")
-        st.metric("Positive/Negative Ratio", f"{pos}:{neg}")
         st.write("Top 3 Issues:", ", ".join(cat_pivot.head(3)["Category"].tolist()))
 
 
@@ -2006,7 +2005,6 @@ if file and validate_file(file):
                         cat_chart = cat_pivot[cat_pivot["Category"] != "Uncategorized"]
                         if not cat_chart.empty:
                             bar_chart(cat_chart, f"{segment_title} Category Frequency")
-                        st.metric("Positive/Negative Ratio", f"{pos}:{neg}")
 
                         report_text = generate_report(
                             seg_df[


### PR DESCRIPTION
## Summary
- omit the Positive/Negative Ratio metric from the dashboard and segmentation results
- adjust README feature list

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ff38afb64832c984d7adde1701432